### PR TITLE
Remove delayed execution of executing menu item, fixing #279

### DIFF
--- a/UnityMcpBridge/Editor/Tools/MenuItems/MenuItemExecutor.cs
+++ b/UnityMcpBridge/Editor/Tools/MenuItems/MenuItemExecutor.cs
@@ -36,23 +36,12 @@ namespace MCPForUnity.Editor.Tools.MenuItems
 
             try
             {
-                // Execute on main thread using delayCall
-                EditorApplication.delayCall += () =>
+                bool executed = EditorApplication.ExecuteMenuItem(menuPath);
+                if (!executed)
                 {
-                    try
-                    {
-                        bool executed = EditorApplication.ExecuteMenuItem(menuPath);
-                        if (!executed)
-                        {
-                            McpLog.Error($"[MenuItemExecutor] Failed to execute menu item via delayCall: '{menuPath}'. It might be invalid, disabled, or context-dependent.");
-                        }
-                    }
-                    catch (Exception delayEx)
-                    {
-                        McpLog.Error($"[MenuItemExecutor] Exception during delayed execution of '{menuPath}': {delayEx}");
-                    }
-                };
-
+                    McpLog.Error($"[MenuItemExecutor] Failed to execute menu item via delayCall: '{menuPath}'. It might be invalid, disabled, or context-dependent.");
+                    return Response.Error($"Failed to execute menu item '{menuPath}'. It might be invalid, disabled, or context-dependent.");
+                }
                 return Response.Success($"Attempted to execute menu item: '{menuPath}'. Check Unity logs for confirmation or errors.");
             }
             catch (Exception e)

--- a/UnityMcpBridge/UnityMcpServer~/src/tools/manage_menu_item.py
+++ b/UnityMcpBridge/UnityMcpServer~/src/tools/manage_menu_item.py
@@ -13,7 +13,7 @@ from unity_connection import get_unity_connection, async_send_command_with_retry
 def register_manage_menu_item_tools(mcp: FastMCP):
     """Registers the manage_menu_item tool with the MCP server."""
 
-    @mcp.tool()
+    @mcp.tool(description="Manage Unity menu items (execute/list/exists)")
     @telemetry_tool("manage_menu_item")
     async def manage_menu_item(
         ctx: Context,
@@ -25,18 +25,6 @@ def register_manage_menu_item_tools(mcp: FastMCP):
         refresh: Annotated[bool | None,
                            "Optional flag to force refresh of the menu cache when listing"] = None,
     ) -> dict[str, Any]:
-        """Manage Unity menu items (execute/list/exists).
-
-        Args:
-            ctx: The MCP context.
-            action: One of 'execute', 'list', 'exists'.
-            menu_path: Menu path for 'execute' or 'exists' (e.g., "File/Save Project").
-            search: Optional filter string for 'list'.
-            refresh: Optional flag to force refresh of the menu cache when listing.
-
-        Returns:
-            A dictionary with operation results ('success', 'data', 'error').
-        """
         # Prepare parameters for the C# handler
         params_dict: dict[str, Any] = {
             "action": action,


### PR DESCRIPTION
This brings the Unity window into focus but that seems to be a better UX for devs. Also streamline manage_menu_item tool info, as FastMCP recommends