### PR TITLE
fix(manage_asset): improve properties parameter parsing

### DIFF
--- a/Server/test_telemetry.py
+++ b/Server/test_telemetry.py
@@ -70,10 +70,10 @@ def test_telemetry_disabled():
 
     # Re-import to get fresh config
     import importlib
-    import telemetry
-    importlib.reload(telemetry)
+    import core.telemetry
+    importlib.reload(core.telemetry)
 
-    core.telemetry import is_telemetry_enabled, record_telemetry, RecordType
+    from core.telemetry import is_telemetry_enabled, record_telemetry, RecordType
 
     _ = is_telemetry_enabled()
 
@@ -95,7 +95,7 @@ def test_data_storage():
     # Silent for tests
 
     try:
-        core.telemetry import get_telemetry
+        from core.telemetry import get_telemetry
 
         collector = get_telemetry()
         data_dir = collector.config.data_dir


### PR DESCRIPTION
This is a pet issue of mine, making sure we don't error out so much when dealing with material properties. Also caught a couple syntax errors in telemetry test from project changes

- Update type annotation to accept dict[str, Any] | str for properties parameter
- Add robust parsing logic that tries JSON first, then ast.literal_eval for Python dict strings
- Log warning and pass through unparseable strings to Unity (for backward compatibility)
- Add detailed logging to track how properties are received and parsed
- Fix syntax errors in test_telemetry.py (missing 'from' in import statements)
- All 82 tests now pass successfully